### PR TITLE
WIP: Fixing Choose File Option Not Working Issue

### DIFF
--- a/app/src/main/java/to/dev/dev_android/view/main/view/CustomWebChromeClient.kt
+++ b/app/src/main/java/to/dev/dev_android/view/main/view/CustomWebChromeClient.kt
@@ -1,0 +1,27 @@
+package to.dev.dev_android.view.main.view
+
+import android.content.Context
+import android.net.Uri
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import to.dev.dev_android.databinding.ActivityMainBinding
+
+
+class CustomWebChromeClient(val context: Context,
+                            val binding: ActivityMainBinding,
+                            private val listener: CustomListener) : WebChromeClient() {
+
+    override fun onShowFileChooser(
+        webView: WebView?,
+        filePathCallback: ValueCallback<Array<Uri>>?,
+        fileChooserParams: FileChooserParams?
+    ): Boolean {
+        listener.launchGallery()
+        return super.onShowFileChooser(webView, filePathCallback, fileChooserParams)
+    }
+
+    interface CustomListener {
+        fun launchGallery()
+    }
+}

--- a/app/src/main/java/to/dev/dev_android/view/main/view/CustomWebChromeClient.kt
+++ b/app/src/main/java/to/dev/dev_android/view/main/view/CustomWebChromeClient.kt
@@ -17,11 +17,11 @@ class CustomWebChromeClient(val context: Context,
         filePathCallback: ValueCallback<Array<Uri>>?,
         fileChooserParams: FileChooserParams?
     ): Boolean {
-        listener.launchGallery()
-        return super.onShowFileChooser(webView, filePathCallback, fileChooserParams)
+        listener.launchGallery(filePathCallback)
+        return true
     }
 
     interface CustomListener {
-        fun launchGallery()
+        fun launchGallery(filePathCallback: ValueCallback<Array<Uri>>?)
     }
 }

--- a/app/src/main/java/to/dev/dev_android/view/main/view/MainActivity.kt
+++ b/app/src/main/java/to/dev/dev_android/view/main/view/MainActivity.kt
@@ -1,14 +1,20 @@
 package to.dev.dev_android.view.main.view
 
 import android.annotation.SuppressLint
+import android.app.Activity
+import android.content.Context
 import android.content.Intent
+import android.database.Cursor
 import android.net.Uri
 import android.os.Bundle
+import android.provider.MediaStore
+import android.util.Log
+import androidx.core.app.ActivityCompat
 import to.dev.dev_android.R
 import to.dev.dev_android.base.activity.BaseActivity
 import to.dev.dev_android.databinding.ActivityMainBinding
 
-class MainActivity : BaseActivity<ActivityMainBinding>() {
+class MainActivity : BaseActivity<ActivityMainBinding>(), CustomWebChromeClient.CustomListener {
 
     override fun layout(): Int {
         return R.layout.activity_main
@@ -38,6 +44,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
         binding.webView.settings.javaScriptEnabled = true
         binding.webView.settings.domStorageEnabled = true
         binding.webView.webViewClient = CustomWebViewClient(this@MainActivity, binding)
+        binding.webView.webChromeClient = CustomWebChromeClient(this@MainActivity, binding, this)
     }
 
     private fun navigateToHome() {
@@ -50,5 +57,53 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
         } else {
             super.onBackPressed()
         }
+    }
+
+    override fun launchGallery() {
+        val intent = Intent()
+        // Show only images, no videos or anything else
+        intent.type = "image/*"
+        intent.action = Intent.ACTION_PICK
+        // Always show the chooser (if there are multiple options available)
+        ActivityCompat.startActivityForResult(
+            this,
+            Intent.createChooser(intent, "Select Picture"),
+            PIC_CHOOSER_REQUEST,
+            null    // No additional data
+        )
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (resultCode == Activity.RESULT_OK) {
+            if (requestCode == PIC_CHOOSER_REQUEST) {
+                if (data != null) {
+                    Log.d("MainActivity", "onActivityResult (line 76): data: ${data.data}")
+                    val realPathFromUri = getRealPathFromUri(this, data.data)
+                    val picPath = realPathFromUri.split("/").last()
+                    Log.d("MainActivity", "onActivityResult (line 87): picPath: $picPath" )
+                    Log.d("MainActivity", "onActivityResult (line 82): $realPathFromUri")
+                    // TODO: Access the file
+                    // TODO: Make the API Call??
+                }
+            }
+        }
+        super.onActivityResult(requestCode, resultCode, data)
+    }
+
+    private fun getRealPathFromUri(context: Context, contentUri: Uri): String {
+        var cursor: Cursor? = null
+        try {
+            val projection = arrayOf(MediaStore.Images.Media.DATA)
+            cursor = context.contentResolver.query(contentUri, projection, null, null, null)
+            val columnIndex = cursor!!.getColumnIndexOrThrow(MediaStore.Images.Media.DATA)
+            cursor.moveToFirst()
+            return cursor.getString(columnIndex)
+        } finally {
+            cursor?.close()
+        }
+    }
+
+    companion object {
+        private const val PIC_CHOOSER_REQUEST = 100
     }
 }


### PR DESCRIPTION
- Adds a *CustomWebChromeClient* that can handle the event to choose file in the webview
- Updates webview to have a *webChromeClient*
- Adds a custom listner interface and let *MainActivity* implement it.
- Creates & Uses Implicit intent to let the Android show a Chooser with the list of apps that can handle the intent
- On successfully receiving the chosen photo back, attempts to get the absolute path

*Note:*

The reason to use a listener interface is to let the activity handle creating the intent to launch gallery and handle the result through "*onActivityResult()*" method. This is a simpler approach.